### PR TITLE
Add client for Meetup API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "activerecord"
 gem "pg"
 gem "http"
 gem 'standalone_migrations'
+gem 'bugsnag'
 
 group :development, :test do
   gem 'factory_girl'

--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ end
 group :test do
   gem 'faker', '~> 1.7'
   gem 'database_cleaner'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     arel (8.0.0)
+    bugsnag (5.3.2)
     builder (3.2.3)
     concurrent-ruby (1.0.5)
     database_cleaner (1.6.1)
@@ -103,6 +104,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord
+  bugsnag
   database_cleaner
   factory_girl
   faker (~> 1.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,8 @@ GEM
     bugsnag (5.3.2)
     builder (3.2.3)
     concurrent-ruby (1.0.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     database_cleaner (1.6.1)
     diff-lcs (1.2.5)
     domain_name (0.5.20170223)
@@ -40,6 +42,7 @@ GEM
       activesupport (>= 3.0.0)
     faker (1.7.3)
       i18n (~> 0.5)
+    hashdiff (0.3.4)
     http (2.2.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -87,6 +90,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    safe_yaml (1.0.4)
     standalone_migrations (5.2.1)
       activerecord (>= 4.2.7, < 5.2.0)
       railties (>= 4.2.7, < 5.2.0)
@@ -98,6 +102,10 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
+    webmock (3.0.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -112,6 +120,7 @@ DEPENDENCIES
   pg
   rspec
   standalone_migrations
+  webmock
 
 RUBY VERSION
    ruby 2.4.1p111

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require 'bugsnag'
 require './config/environment'
 
 Dir.glob('app/models/**/*.rb').each { |r| load r}
-$:.unshift(File.expand_path('../../lib', __FILE__))
+Dir.glob('lib/**/*.rb').each { |r| load r}
 
 # Load development credentials from config file:
 # Copy config/application.yml.example to config/application.yml and fill in the

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -1,6 +1,8 @@
 default: &default
   DATABASE_USER: ubuntu
   DATABASE_PASSWORD: ""
+  MEETUP_KEY: "your-key-here"
+  BUGSNAG_KEY: ""
 
 development:
   <<: *default

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -11,3 +11,5 @@ development:
 test:
   <<: *default
   DATABASE_NAME: maynard_test
+  MEETUP_KEY: "real-key-not-needed"
+  LOG_LEVEL: "WARN"

--- a/lib/MMLog.rb
+++ b/lib/MMLog.rb
@@ -1,0 +1,12 @@
+require 'logger'
+
+class MMLog
+  def self.log
+    if @logger.nil?
+      @logger = Logger.new STDOUT
+      @logger.level = ENV['LOG_LEVEL'] || Logger::DEBUG
+      @logger.datetime_format = '%Y-%m-%d %H:%M:%S '
+    end
+    @logger
+  end
+end

--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -1,0 +1,40 @@
+require 'rack'
+require 'MMLog'
+
+module Meetup
+  class Api
+    OK = '200'
+    BASE_URI = 'api.meetup.com'
+
+    def initialize(data_type:, options:)
+      @data_type = data_type
+      @options = options
+      @options[:key] = ENV['MEETUP_KEY']
+    end
+
+    # https://www.meetup.com/meetup_api/docs/#making_request
+    # https://www.meetup.com/meetup_api/docs/#responses
+    # https://www.meetup.com/meetup_api/docs/#errors
+    def get_response
+      url = build_url
+      MMLog.log.debug(url)
+      @response = HTTP.get(url)
+      @response.parse(:json)
+
+      rescue => e
+        Bugsnag.notify("Error parsing Meetup response: #{e}")
+        { "errors" => [{"message": "Error parsing Meetup response"}] }
+    end
+
+    protected
+
+    def build_url
+      query_string = Rack::Utils.build_query(@options)
+      "#{base_url}?#{query_string}"
+    end
+
+    def base_url
+      "https://#{BASE_URI}/#{@data_type.join('/')}/"
+    end
+  end
+end

--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -26,12 +26,12 @@ module Meetup
         { "errors" => [{"message": "Error parsing Meetup response"}] }
     end
 
-    protected
-
     def build_url
       query_string = Rack::Utils.build_query(@options)
       "#{base_url}?#{query_string}"
     end
+
+    protected
 
     def base_url
       "https://#{BASE_URI}/#{@data_type.join('/')}/"

--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -1,5 +1,4 @@
 require 'rack'
-require 'MMLog'
 
 module Meetup
   class Api
@@ -43,8 +42,8 @@ module Meetup
       if response_success?
         body
       else
-        errors = body[:errors] || { "errors" => [{"message": "Meetup response has no body"}] }
-        raise errors["errors"].map { |h| h[:message] }.join("; ")
+        errors = body["errors"] || [{"message": "Meetup response has no body"}]
+        raise errors.map { |h| h["message"] }.join("; ")
       end
     end
 

--- a/spec/lib/meetup/api_spec.rb
+++ b/spec/lib/meetup/api_spec.rb
@@ -1,0 +1,55 @@
+require 'meetup/api'
+
+describe Meetup::Api do
+  it 'fails without #options' do
+    expect {
+      Meetup::Api.new(data_type: [])
+    }.to raise_error(ArgumentError)
+  end
+
+  it 'fails without #data_type' do
+    expect {
+      Meetup::Api.new(options: {cat: 'mouse'})
+    }.to raise_error(ArgumentError)
+  end
+
+  context 'when building url' do
+    let(:meetup_api) {
+      Meetup::Api.new(
+        data_type: ['test_endpoint'],
+        options: {cat: 'mouse',  dog: ',3m'})
+    }
+
+    it 'sets #options as part of the query string' do
+      expect(meetup_api.build_url).to include('cat=mouse')
+    end
+
+    it 'sets #data_type as part of the url' do
+      expect(meetup_api.build_url).to include("/test_endpoint/")
+    end
+
+    it 'handles any url encoding' do
+      expect(meetup_api.build_url).to include(ERB::Util.url_encode ',3m')
+    end
+  end
+
+  context 'when getting response' do
+    let(:response) do
+      {
+        "id"=>12345,
+        "name"=>"Meetup Group Name",
+        "link"=>"https://www.meetup.com/Meetup-Group-Name/",
+      }
+    end
+    let(:meetup_api) { Meetup::Api.new(data_type: [], options: {}) }
+
+    before do
+      stub_request(:get, Regexp.new(Meetup::Api::BASE_URI))
+        .to_return(body: response.to_json, status: 200, headers: {})
+    end
+
+    it 'returns json' do
+      expect(meetup_api.get_response).to eq response
+    end
+  end
+end

--- a/spec/lib/meetup/api_spec.rb
+++ b/spec/lib/meetup/api_spec.rb
@@ -43,13 +43,19 @@ describe Meetup::Api do
     end
     let(:meetup_api) { Meetup::Api.new(data_type: [], options: {}) }
 
-    before do
+    it 'returns hash' do
       stub_request(:get, Regexp.new(Meetup::Api::BASE_URI))
         .to_return(body: response.to_json, status: 200, headers: {})
+
+      expect(meetup_api.get_response).to eq response
     end
 
-    it 'returns json' do
-      expect(meetup_api.get_response).to eq response
+    it 'notifies Bugsnag on error' do
+      stub_request(:get, Regexp.new(Meetup::Api::BASE_URI))
+        .to_return(body: '{}', status: 404, headers: {})
+
+      expect(Bugsnag).to receive(:notify).once
+      expect(meetup_api.get_response).to include("errors")
     end
   end
 end

--- a/spec/lib/meetup/api_spec.rb
+++ b/spec/lib/meetup/api_spec.rb
@@ -1,5 +1,3 @@
-require 'meetup/api'
-
 describe Meetup::Api do
   it 'fails without #options' do
     expect {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ ENV["DB"] = "test"
 require './config/application'
 require 'factory_girl'
 require 'faker'
+require 'webmock/rspec'
 Dir[File.join('./spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|


### PR DESCRIPTION
<!--- Which GitHub issue are you closing? -->
closes #16

<!--- What kinds of changes did you make? -->
## Description:
- Client lib for making simple GET requests to the Meetup API
- Spec + webmock
- Logger lib added; default level is debug but we can raise that to INFO, or configure it your own way in the environment variables. 
- Bugsnag added

<!--- How did you test this? -->
<!--- How should someone else test this? -->
## QA:

Add your personal [API Key](https://secure.meetup.com/meetup_api/key/) to the environment config. You can run `rspec` and then you have to use the console to test the code:
```ruby
m = Meetup::Api.new(data_type: ["Women-Who-Code-Seattle"], options: {})
m.get_response
```

<!--- Any notes you'd like to include... -->
<!--- i.e. database migrations or deployment information. -->
## Notes:
n/a

@WomenWhoCode/meet-maynard-reviewers
