### PR TITLE
Add rate limiting for api requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tmp/
+log/
 cookbooks/
 .vagrant/
 ubuntu-xenial-16.04-cloudimg-console.log

--- a/lib/MMLog.rb
+++ b/lib/MMLog.rb
@@ -1,6 +1,6 @@
 require 'logger'
 
-class MMLog
+class MMLog < Logger
   def self.log
     if @logger.nil?
       @logger = Logger.new STDOUT
@@ -9,4 +9,15 @@ class MMLog
     end
     @logger
   end
+
+  def format_message(severity, timestamp, progname, msg)
+    formatted_time = timestamp.strftime("%Y-%m-%d %H:%M:%S.") << timestamp.usec.to_s[0..2].rjust(3)
+    "[%s] %s\n" % [formatted_time, msg]
+  end
 end
+
+# Usage: MMLOG.info(<stuff>)
+# (or whatever level of debug info you want to use)
+logfile = File.open('log/mm.log','a')
+logfile.sync = true
+MMLOG = MMLog.new(logfile)

--- a/lib/MMLog.rb
+++ b/lib/MMLog.rb
@@ -1,6 +1,6 @@
 require 'logger'
 
-class MMLog < Logger
+class MMLog
   def self.log
     if @logger.nil?
       @logger = Logger.new STDOUT
@@ -9,15 +9,4 @@ class MMLog < Logger
     end
     @logger
   end
-
-  def format_message(severity, timestamp, progname, msg)
-    formatted_time = timestamp.strftime("%Y-%m-%d %H:%M:%S.") << timestamp.usec.to_s[0..2].rjust(3)
-    "[%s] %s\n" % [formatted_time, msg]
-  end
 end
-
-# Usage: MMLOG.info(<stuff>)
-# (or whatever level of debug info you want to use)
-logfile = File.open('log/mm.log','a')
-logfile.sync = true
-MMLOG = MMLog.new(logfile)

--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -37,9 +37,8 @@ module Meetup
     end
 
     def throttle_wait
-      return 0 if remaining_requests > 0
+      return if remaining_requests > 0
       sleep reset_seconds
-      reset_seconds
     end
 
     protected

--- a/spec/lib/meetup/api_spec.rb
+++ b/spec/lib/meetup/api_spec.rb
@@ -87,17 +87,17 @@ describe Meetup::Api do
   context "#throttle_wait" do
     let(:meetup_api) { Meetup::Api.new(data_type: [], options: {}) }
 
-    it "returns 0 if remaining requests is positive" do
-      expect_any_instance_of(Meetup::Api).to_not receive(:sleep)
+    it "does not sleep if remaining requests is positive" do
       meetup_api.remaining_requests = 5
-      expect(meetup_api.throttle_wait).to eq 0
+      expect_any_instance_of(Meetup::Api).to_not receive(:sleep)
+      meetup_api.throttle_wait
     end
 
     it "returns reset seconds if remaining requests is negative" do
       meetup_api.remaining_requests = 0
       meetup_api.reset_seconds = 10
       expect_any_instance_of(Meetup::Api).to receive(:sleep).with(meetup_api.reset_seconds)
-      expect(meetup_api.throttle_wait).to eq meetup_api.reset_seconds
+      meetup_api.throttle_wait
     end
   end
 end

--- a/spec/lib/meetup/api_spec.rb
+++ b/spec/lib/meetup/api_spec.rb
@@ -56,7 +56,7 @@ describe Meetup::Api do
         expect(meetup_api.reset_seconds).to eq 10
       end
 
-      it "series of requests calls sleep" do
+      it "calls sleep after a series of requests" do
         expect_any_instance_of(Meetup::Api).to receive(:sleep).with(10).once
         meetup_request_success_stub(remaining: 0)
         # This call uses default initializing and won't call sleep.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,8 @@ require 'webmock/rspec'
 Dir[File.join('./spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
+  config.include Webmocks
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/support/webmocks.rb
+++ b/spec/support/webmocks.rb
@@ -1,0 +1,8 @@
+module Webmocks
+  def meetup_request_success_stub(remaining: 29, reset: 10)
+    stub_request(:get, Regexp.new(Meetup::Api::BASE_URI))
+    .to_return(body: response.to_json, status: 200,
+               headers: {"X-Ratelimit-Remaining"=>"#{remaining}",
+                         "X-Ratelimit-Reset"=>"#{reset}"})
+  end
+end


### PR DESCRIPTION
<!--- Which GitHub issue are you closing? -->
closes #5 

<!--- What kinds of changes did you make? -->
## Description:
- Captures rate limiting header response values from previous api requests and sleeps if necessary before making next call

<!--- How did you test this? -->
<!--- How should someone else test this? -->
## QA:
- [x] In console:

```
$ irb
irb(main):001:0> require './config/application'
=> true
irb(main):002:0> m = Meetup::Api.new(data_type: ["Women-Who-Code-Seattle"], options: {})
=> #<Meetup::Api:0x007fac325b0e60 @data_type=["Women-Who-Code-Seattle"], @options={:key=>"813b1066613232c80316348d2a11"}, @remaining_requests=1, @reset_seconds=1>
irb(main):003:0> (1..40).each do
irb(main):004:1* m.get_response
irb(main):005:1> end
```

After 30 hits there should be a delay of a few seconds before it continues on making requests.

If you comment out the `throttle_wait` call in the `get_response` method and run the same 40 calls again then you will get a `Credentials have been throttled more than the allowed times in one hour` error.

<!--- Any notes you'd like to include... -->
<!--- i.e. database migrations or deployment information. -->
## Notes:



@WomenWhoCode/meet-maynard-reviewers
