### PR TITLE
Pull event data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'standalone_migrations'
 gem 'bugsnag'
 gem 'pry'
 gem 'nitlink'
+gem 'i18n'
 
 group :development, :test do
   gem 'factory_girl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,7 @@ DEPENDENCIES
   factory_girl
   faker (~> 1.7)
   http
+  i18n
   nitlink
   pg
   pry

--- a/app/models/concerns/retrievable.rb
+++ b/app/models/concerns/retrievable.rb
@@ -1,7 +1,7 @@
 module Retrievable
   extend ActiveSupport::Concern
 
-  DATE_FIELDS = %w(founded_date pro_join_date last_event next_event)
+  DATE_FIELDS = %w(founded_date pro_join_date last_event next_event time)
 
   module ClassMethods
     def insert_records(records)

--- a/app/models/concerns/retrievable.rb
+++ b/app/models/concerns/retrievable.rb
@@ -1,0 +1,24 @@
+module Retrievable
+  extend ActiveSupport::Concern
+
+  DATE_FIELDS = %w(founded_date pro_join_date last_event next_event)
+
+  module ClassMethods
+    def insert_records(records)
+      records.each do |record|
+        obj = self.where("#{meetup_primary_key}": record["id"]).first_or_create
+        record.delete("id")
+        record.each do |k, v|
+          setter = "#{k}="
+          next unless obj.respond_to?(setter)
+          if DATE_FIELDS.include?(k)
+            obj.send(setter, DateTime.strptime("#{v}",'%Q'))
+          else
+            obj.send(setter, v)
+          end
+        end
+        obj.save
+      end
+    end
+  end
+end

--- a/app/models/concerns/retrievable.rb
+++ b/app/models/concerns/retrievable.rb
@@ -8,6 +8,7 @@ module Retrievable
       records.each do |record|
         obj = self.where("#{meetup_primary_key}": record["id"]).first_or_create
         record.delete("id")
+        record = flatten_record(record)
         record.each do |k, v|
           setter = "#{k}="
           next unless obj.respond_to?(setter)
@@ -19,6 +20,20 @@ module Retrievable
         end
         obj.save
       end
+    end
+
+    private
+
+    def flatten_record(record)
+      sub_hash = {}
+      record.each do |k, v|
+        next unless v.is_a?(Hash)
+        record.delete(k)
+        v.each do |sub_k, sub_v|
+          sub_hash["#{k}_#{sub_k}"] = sub_v
+        end
+      end
+      record.merge(sub_hash)
     end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,5 +5,26 @@ class Event < ActiveRecord::Base
     def meetup_primary_key
       :event_id
     end
+
+    def retrieve_events(group_stat)
+      last_stored_time = group_stat.last_stored_event_time
+
+      if last_stored_time
+        since_time = I18n.l last_stored_time, format: :meetup_scroll_since
+        options = { scroll: "since:#{since_time}" }
+        m = Meetup::Api.new(data_type: [group_stat.urlname, "events"],
+                            options: options)
+      else
+        m = Meetup::Api.new(data_type: [group_stat.urlname, "events"])
+      end
+
+      data = m.get_response
+      while data
+        most_recent_event_time = data.map{|hash| hash["time"]}.max
+        Event.insert_records(data)
+        data = m.get_next_page(Date.today)
+      end
+      group_stat.update(last_stored_event_time: DateTime.strptime(most_recent_event_time.to_s, '%Q'))
+    end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,24 +7,29 @@ class Event < ActiveRecord::Base
     end
 
     def retrieve_events(group_stat)
-      last_stored_time = group_stat.last_stored_event_time
+      begin
+        last_stored_time = group_stat.last_stored_event_time
 
-      if last_stored_time
-        since_time = I18n.l last_stored_time, format: :meetup_scroll_since
-        options = { scroll: "since:#{since_time}" }
-        m = Meetup::Api.new(data_type: [group_stat.urlname, "events"],
-                            options: options)
-      else
-        m = Meetup::Api.new(data_type: [group_stat.urlname, "events"])
-      end
+        if last_stored_time
+          since_time = I18n.l last_stored_time, format: :meetup_scroll_since
+          options = { scroll: "since:#{since_time}" }
+          m = Meetup::Api.new(data_type: [group_stat.urlname, "events"],
+                              options: options)
+        else
+          m = Meetup::Api.new(data_type: [group_stat.urlname, "events"])
+        end
 
-      data = m.get_response
-      while data
-        most_recent_event_time = data.map{|hash| hash["time"]}.max
-        Event.insert_records(data)
-        data = m.get_next_page(Date.today)
+        data = m.get_response
+        while data && data.any?
+          most_recent_event_time = data.map{|hash| hash["time"]}.max
+          Event.insert_records(data)
+          data = m.get_next_page(Date.today)
+        end
+        group_stat.update(last_stored_event_time: DateTime.strptime(most_recent_event_time.to_s, '%Q')) if most_recent_event_time
+
+      rescue Exception => e
+        Bugsnag.notify(e, group_id: group_stat.id)
       end
-      group_stat.update(last_stored_event_time: DateTime.strptime(most_recent_event_time.to_s, '%Q'))
     end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,10 +10,10 @@ class Event < ActiveRecord::Base
 
     def retrieve_events(group_stat)
       begin
-        last_stored_time = group_stat.last_stored_event_time
+        last_event_time = group_stat.events.order(time: :desc).first.try(:time)
 
-        if last_stored_time
-          since_time = I18n.l last_stored_time, format: :meetup_scroll_since
+        if last_event_time
+          since_time = I18n.l last_event_time, format: :meetup_scroll_since
           options = { scroll: "since:#{since_time}" }
           m = Meetup::Api.new(data_type: [group_stat.urlname, "events"],
                               options: options)
@@ -23,11 +23,9 @@ class Event < ActiveRecord::Base
 
         data = m.get_response
         while data && data.any?
-          most_recent_event_time = data.map{|hash| hash["time"]}.max
           Event.insert_records(data)
           data = m.get_next_page(Date.today)
         end
-        group_stat.update(last_stored_event_time: DateTime.strptime(most_recent_event_time.to_s, '%Q')) if most_recent_event_time
 
       rescue Exception => e
         Bugsnag.notify(e, group_id: group_stat.id)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,9 @@
+class Event < ActiveRecord::Base
+  include Retrievable
+
+  class << self
+    def meetup_primary_key
+      :event_id
+    end
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,8 @@
 class Event < ActiveRecord::Base
   include Retrievable
 
+  belongs_to :group, class_name: "GroupStat", primary_key: :group_id
+
   class << self
     def meetup_primary_key
       :event_id

--- a/app/models/group_stat.rb
+++ b/app/models/group_stat.rb
@@ -1,6 +1,8 @@
 class GroupStat < ActiveRecord::Base
   include Retrievable
 
+  has_many :events, primary_key: :group_id, foreign_key: :group_id
+
   class << self
     def meetup_primary_key
       :group_id

--- a/app/models/group_stat.rb
+++ b/app/models/group_stat.rb
@@ -1,22 +1,9 @@
 class GroupStat < ActiveRecord::Base
-  DATE_FIELDS = %w(founded_date pro_join_date last_event next_event)
+  include Retrievable
 
   class << self
-    def insert_records(records)
-      records.each do |record|
-        group_stat = self.where(group_id: record["id"]).first_or_create
-        record.delete("id")
-        record.each do |k,v|
-          setter = "#{k}="
-          next unless group_stat.respond_to?(setter)
-          if DATE_FIELDS.include?(k)
-            group_stat.send(setter, DateTime.strptime("#{v}",'%Q'))
-          else
-            group_stat.send(setter,v)
-          end
-        end
-        group_stat.save
-      end
+    def meetup_primary_key
+      :group_id
     end
   end
 end

--- a/config/active_record.rb
+++ b/config/active_record.rb
@@ -1,5 +1,6 @@
 require 'active_record'
-logfile = File.open('log/active_record.log','a')
-logfile.sync = true
-ActiveRecord::Base.logger = Logger.new(logfile)  
-
+if ENV["DB"] != "production"
+  logfile = File.open('log/active_record.log','a')
+  logfile.sync = true
+  ActiveRecord::Base.logger = Logger.new(logfile)
+end

--- a/config/active_record.rb
+++ b/config/active_record.rb
@@ -1,6 +1,4 @@
 require 'active_record'
-if ENV["DB"] != "production"
-  logfile = File.open('log/active_record.log','a')
-  logfile.sync = true
-  ActiveRecord::Base.logger = Logger.new(logfile)
+if ENV["DB"] == "production"
+  ActiveRecord::Base.logger = Logger.new(STDOUT)
 end

--- a/config/active_record.rb
+++ b/config/active_record.rb
@@ -1,0 +1,5 @@
+require 'active_record'
+logfile = File.open('log/active_record.log','a')
+logfile.sync = true
+ActiveRecord::Base.logger = Logger.new(logfile)  
+

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,7 @@ require 'erb'
 require 'bugsnag'
 
 require './config/environment'
+require './config/i18n'
 
 Dir.glob('app/models/**/*.rb').each { |r| load r}
 Dir.glob('lib/**/*.rb').each { |r| load r}

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,8 +8,8 @@ require 'bugsnag'
 
 require './config/i18n'
 
-Dir.glob('app/models/**/*.rb').each { |r| load r}
-Dir.glob('lib/**/*.rb').each { |r| load r}
+Dir[File.dirname(__FILE__) + "/../app/**/*.rb"].each { |file| require file }
+Dir[File.dirname(__FILE__) + "/../lib/**/*.rb"].each { |file| require file }
 
 # Load development credentials from config file:
 # Copy config/application.yml.example to config/application.yml and fill in the

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ require 'bugsnag'
 
 require './config/i18n'
 
+Dir[File.dirname(__FILE__) + "/../app/models/concerns/*.rb"].each { |file| require file }
 Dir[File.dirname(__FILE__) + "/../app/**/*.rb"].each { |file| require file }
 Dir[File.dirname(__FILE__) + "/../lib/**/*.rb"].each { |file| require file }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,11 +1,11 @@
+require './config/environment'
 require 'pg'
-require 'active_record'
+require './config/active_record'
 require 'yaml'
 require 'http'
 require 'erb'
 require 'bugsnag'
 
-require './config/environment'
 require './config/i18n'
 
 Dir.glob('app/models/**/*.rb').each { |r| load r}

--- a/config/i18n.rb
+++ b/config/i18n.rb
@@ -1,0 +1,3 @@
+require 'i18n'
+I18n.config.available_locales = :en
+I18n.load_path = Dir['config/locales/*.yml']

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,4 @@
+en:
+  time:
+    formats:
+      meetup_scroll_since: "%Y-%m-%dT%H:%M:%S.000-00:00"

--- a/db/migrate/20170610003929_create_events.rb
+++ b/db/migrate/20170610003929_create_events.rb
@@ -1,0 +1,10 @@
+class CreateEvents < ActiveRecord::Migration[5.1]
+  def change
+    create_table :events do |t|
+      t.string :event_id
+      t.integer :group_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20170619173125_add_time_to_events.rb
+++ b/db/migrate/20170619173125_add_time_to_events.rb
@@ -1,0 +1,5 @@
+class AddTimeToEvents < ActiveRecord::Migration[5.1]
+  def change
+    add_column :events, :time, :timestamp
+  end
+end

--- a/db/migrate/20170619174111_add_last_event_time_stored_to_group_stats.rb
+++ b/db/migrate/20170619174111_add_last_event_time_stored_to_group_stats.rb
@@ -1,5 +1,5 @@
 class AddLastEventTimeStoredToGroupStats < ActiveRecord::Migration[5.1]
   def change
-    add_column :group_stats, :last_event_time_stored, :timestamp
+    add_column :group_stats, :last_stored_event_time, :timestamp
   end
 end

--- a/db/migrate/20170619174111_add_last_event_time_stored_to_group_stats.rb
+++ b/db/migrate/20170619174111_add_last_event_time_stored_to_group_stats.rb
@@ -1,0 +1,5 @@
+class AddLastEventTimeStoredToGroupStats < ActiveRecord::Migration[5.1]
+  def change
+    add_column :group_stats, :last_event_time_stored, :timestamp
+  end
+end

--- a/db/migrate/20170619174111_add_last_event_time_stored_to_group_stats.rb
+++ b/db/migrate/20170619174111_add_last_event_time_stored_to_group_stats.rb
@@ -1,5 +1,0 @@
-class AddLastEventTimeStoredToGroupStats < ActiveRecord::Migration[5.1]
-  def change
-    add_column :group_stats, :last_stored_event_time, :timestamp
-  end
-end

--- a/db/migrate/20170620164949_remove_last_stored_event_time_from_group_stats.rb
+++ b/db/migrate/20170620164949_remove_last_stored_event_time_from_group_stats.rb
@@ -1,0 +1,5 @@
+class RemoveLastStoredEventTimeFromGroupStats < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :group_stats, :last_stored_event_time, :timestamp
+  end
+end

--- a/db/migrate/20170620164949_remove_last_stored_event_time_from_group_stats.rb
+++ b/db/migrate/20170620164949_remove_last_stored_event_time_from_group_stats.rb
@@ -1,5 +1,0 @@
-class RemoveLastStoredEventTimeFromGroupStats < ActiveRecord::Migration[5.1]
-  def change
-    remove_column :group_stats, :last_stored_event_time, :timestamp
-  end
-end

--- a/db/migrate/20170621200414_add_group_urlname_to_events.rb
+++ b/db/migrate/20170621200414_add_group_urlname_to_events.rb
@@ -1,0 +1,5 @@
+class AddGroupUrlnameToEvents < ActiveRecord::Migration[5.1]
+  def change
+    add_column :events, :group_urlname, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170619173125) do
+ActiveRecord::Schema.define(version: 20170619174111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 20170619173125) do
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "last_event_time_stored"
   end
 
   create_table "watermarks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 20170619174111) do
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "last_event_time_stored"
+    t.datetime "last_stored_event_time"
   end
 
   create_table "watermarks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170620164949) do
+ActiveRecord::Schema.define(version: 20170621200414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20170620164949) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "time"
+    t.string "group_urlname"
   end
 
   create_table "group_stats", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170610003929) do
+ActiveRecord::Schema.define(version: 20170619173125) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20170610003929) do
     t.integer "group_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "time"
   end
 
   create_table "group_stats", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170619174111) do
+ActiveRecord::Schema.define(version: 20170620164949) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,7 +51,6 @@ ActiveRecord::Schema.define(version: 20170619174111) do
     t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "last_stored_event_time"
   end
 
   create_table "watermarks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170607214332) do
+ActiveRecord::Schema.define(version: 20170610003929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "events", force: :cascade do |t|
+    t.string "event_id"
+    t.integer "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "group_stats", force: :cascade do |t|
     t.integer "group_id"

--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -8,7 +8,7 @@ module Meetup
 
     attr_accessor :remaining_requests, :reset_seconds
 
-    def initialize(data_type:, options:)
+    def initialize(data_type:, options: {})
       @data_type = data_type
       @options = options
       @options[:key] = ENV['MEETUP_KEY']

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -14,4 +14,19 @@ namespace :data_import do
       Bugsnag.notify(e)
     end
   end
+
+  desc "pull event data. Usage: rake data_import:events['Women-Who-Code-Silicon-Valley']"
+  task :events, [:urlname] do |t, args|
+    urlname = args[:urlname]
+    abort("urlname parameter required: rake data_import:events['Women-Who-Code-Silicon-Valley']") unless urlname.present?
+
+    begin
+      m = Meetup::Api.new(data_type: [urlname, "events"], options: {})
+      data = m.get_response
+      Event.insert_records(data)
+
+    rescue Exception => e
+      Bugsnag.notify(e)
+    end
+  end
 end

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -17,16 +17,11 @@ namespace :data_import do
 
   desc "pull event data. Usage: rake data_import:events['Women-Who-Code-Silicon-Valley']"
   task :events, [:urlname] do |t, args|
-    urlname = args[:urlname]
-    abort("urlname parameter required: rake data_import:events['Women-Who-Code-Silicon-Valley']") unless urlname.present?
+    scope = args[:urlname].present? ? GroupStat.where(urlname: args[:urlname]) : GroupStat.all
 
-    begin
-      m = Meetup::Api.new(data_type: [urlname, "events"])
-      data = m.get_response
-      Event.insert_records(data)
-
-    rescue Exception => e
-      Bugsnag.notify(e)
+    scope.find_each do |group_stat|
+      next unless group_stat.urlname.present?
+      Event.retrieve_events(group_stat)
     end
   end
 end

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -3,7 +3,7 @@ namespace :data_import do
   task :pro_group, [:group] do |t, args|
     begin
       group = args[:group].presence || 'womenwhocode'
-      m = Meetup::Api.new(data_type: ["pro", group, "groups"], options: {})
+      m = Meetup::Api.new(data_type: ["pro", group, "groups"])
       data = m.get_response
       while data
         GroupStat.insert_records(data)
@@ -21,7 +21,7 @@ namespace :data_import do
     abort("urlname parameter required: rake data_import:events['Women-Who-Code-Silicon-Valley']") unless urlname.present?
 
     begin
-      m = Meetup::Api.new(data_type: [urlname, "events"], options: {})
+      m = Meetup::Api.new(data_type: [urlname, "events"])
       data = m.get_response
       Event.insert_records(data)
 

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :event do
+    event_id { Faker::Lorem.characters(12) }
+  end
+end

--- a/spec/factories/group_stats.rb
+++ b/spec/factories/group_stats.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :group_stat do
     group_id { Faker::Number.number(6) }
+    urlname "WomenWhoCode-Silicon-Valley"
   end
 end

--- a/spec/factories/group_stats.rb
+++ b/spec/factories/group_stats.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :group_stat do
     group_id { Faker::Number.number(6) }
-    urlname "WomenWhoCode-Silicon-Valley"
+    urlname "Women-Who-Code-Silicon-Valley"
   end
 end

--- a/spec/lib/meetup/api_spec.rb
+++ b/spec/lib/meetup/api_spec.rb
@@ -1,8 +1,8 @@
 describe Meetup::Api do
-  it 'fails without #options' do
+  it 'does not fail without #options' do
     expect {
       Meetup::Api.new(data_type: [])
-    }.to raise_error(ArgumentError)
+    }.to_not raise_error
   end
 
   it 'fails without #data_type' do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -80,21 +80,15 @@ RSpec.describe Event, type: :model do
       meetup_request_success_stub
     end
 
-    it "does not pass scroll parameter if last_stored_event_time is null" do
+    it "does not pass scroll parameter if no events" do
       expect(Meetup::Api).to receive(:new).with(data_type: [group_stat.urlname, "events"]).and_return(Meetup::Api.new(data_type: []))
       Event.retrieve_events(group_stat)
     end
 
-    it "passes scroll parameter if last_stored_event_time is not null" do
-      group_stat.update(last_stored_event_time: Time.utc(2017,6,19,10,28,14))
+    it "passes scroll parameter if events exist" do
+      create(:event, time: Time.utc(2017,6,19,10,28,14), group_id: group_stat.group_id)
       expect(Meetup::Api).to receive(:new).with(data_type: [group_stat.urlname, "events"], options: { scroll: "since:2017-06-19T10:28:14.000-00:00" } ).and_return(Meetup::Api.new(data_type: []))
       Event.retrieve_events(group_stat)
-    end
-
-    it "sets the last_stored_event_time on the group_stat" do
-      Event.retrieve_events(group_stat)
-      group_stat.reload
-      expect(group_stat.last_stored_event_time).to eq Time.utc(2017,6,13,2,0,0)
     end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,38 +1,39 @@
 RSpec.describe Event, type: :model do
-  describe ".insert_records" do
-    let(:data) {
-      [
-        {
-          "created"=>1494405694000,
-          "duration"=>7200000,
-          "id"=>"cqcpbnywjbqb",
-          "name"=>"Cracking Code - (remote/online) Study Group",
-          "status"=>"upcoming",
-          "time"=>1497319200000,
-          "updated"=>1496640174000,
-          "utc_offset"=>-25200000,
-          "waitlist_count"=>0,
-          "yes_rsvp_count"=>31,
-          "group"=> {
-            "created"=>1399992406000,
-            "name"=>"Women Who Code Silicon Valley",
-            "id"=>14429832,
-            "join_mode"=>"open",
-            "lat"=>37.400001525878906,
-            "lon"=>-122.01000213623047,
-            "urlname"=>"Women-Who-Code-Silicon-Valley",
-            "who"=>"Coders",
-            "localized_location"=>"Sunnyvale, CA",
-            "region"=>"en_US"
-          },
-          "link"=>"https://www.meetup.com/Women-Who-Code-Silicon-Valley/events/239890721/",
-          "description"=>"a"*1000,
-          "how_to_find_us"=>"Remote meeting (no physical location) - must email wwc.cracking.code@gmail.com",
-          "visibility"=>"public"
-        }
-      ]
-    }
+  let(:group_stat) { create(:group_stat, group_id: 14429832) }
+  let(:data) {
+    [
+      {
+        "created"=>1494405694000,
+        "duration"=>7200000,
+        "id"=>"cqcpbnywjbqb",
+        "name"=>"Cracking Code - (remote/online) Study Group",
+        "status"=>"upcoming",
+        "time"=>1497319200000,
+        "updated"=>1496640174000,
+        "utc_offset"=>-25200000,
+        "waitlist_count"=>0,
+        "yes_rsvp_count"=>31,
+        "group"=> {
+          "created"=>1399992406000,
+          "name"=>"Women Who Code Silicon Valley",
+          "id"=>14429832,
+          "join_mode"=>"open",
+          "lat"=>37.400001525878906,
+          "lon"=>-122.01000213623047,
+          "urlname"=>"Women-Who-Code-Silicon-Valley",
+          "who"=>"Coders",
+          "localized_location"=>"Sunnyvale, CA",
+          "region"=>"en_US"
+        },
+        "link"=>"https://www.meetup.com/Women-Who-Code-Silicon-Valley/events/239890721/",
+        "description"=>"a"*1000,
+        "how_to_find_us"=>"Remote meeting (no physical location) - must email wwc.cracking.code@gmail.com",
+        "visibility"=>"public"
+      }
+    ]
+  }
 
+  describe ".insert_records" do
     it "increases event records" do
       expect {
         Event.insert_records(data)
@@ -59,6 +60,30 @@ RSpec.describe Event, type: :model do
       Event.insert_records(data)
       event.reload
       expect(event.group_id).to eq 14429832
+    end
+  end
+
+  describe ".retrieve_events" do
+    let(:response) { data }
+    before do
+      meetup_request_success_stub
+    end
+
+    it "does not pass scroll parameter if last_stored_event_time is null" do
+      expect(Meetup::Api).to receive(:new).with(data_type: [group_stat.urlname, "events"]).and_return(Meetup::Api.new(data_type: []))
+      Event.retrieve_events(group_stat)
+    end
+
+    it "passes scroll parameter if last_stored_event_time is not null" do
+      group_stat.update(last_stored_event_time: Time.utc(2017,6,19,10,28,14))
+      expect(Meetup::Api).to receive(:new).with(data_type: [group_stat.urlname, "events"], options: { scroll: "since:2017-06-19T10:28:14.000-00:00" } ).and_return(Meetup::Api.new(data_type: []))
+      Event.retrieve_events(group_stat)
+    end
+
+    it "sets the last_stored_event_time on the group_stat" do
+      Event.retrieve_events(group_stat)
+      group_stat.reload
+      expect(group_stat.last_stored_event_time).to eq Time.utc(2017,6,13,2,0,0)
     end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,4 +1,15 @@
 RSpec.describe Event, type: :model do
+  it "has a valid factory" do
+    event = build(:event)
+    expect(event.valid?).to be true
+  end
+
+  it "belongs to a group" do
+    group_stat = create(:group_stat, group_id: 12345)
+    event = create(:event, group_id: group_stat.group_id)
+    expect(event.group).to eq group_stat
+  end
+
   let(:group_stat) { create(:group_stat, group_id: 14429832) }
   let(:data) {
     [

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe Event, type: :model do
+  describe ".insert_records" do
+    let(:data) {
+      [
+        {
+          "created"=>1494405694000,
+          "duration"=>7200000,
+          "id"=>"cqcpbnywjbqb",
+          "name"=>"Cracking Code - (remote/online) Study Group",
+          "status"=>"upcoming",
+          "time"=>1497319200000,
+          "updated"=>1496640174000,
+          "utc_offset"=>-25200000,
+          "waitlist_count"=>0,
+          "yes_rsvp_count"=>31,
+          "group"=> {
+            "created"=>1399992406000,
+            "name"=>"Women Who Code Silicon Valley",
+            "id"=>14429832,
+            "join_mode"=>"open",
+            "lat"=>37.400001525878906,
+            "lon"=>-122.01000213623047,
+            "urlname"=>"Women-Who-Code-Silicon-Valley",
+            "who"=>"Coders",
+            "localized_location"=>"Sunnyvale, CA",
+            "region"=>"en_US"
+          },
+          "link"=>"https://www.meetup.com/Women-Who-Code-Silicon-Valley/events/239890721/",
+          "description"=>"a"*1000,
+          "how_to_find_us"=>"Remote meeting (no physical location) - must email wwc.cracking.code@gmail.com",
+          "visibility"=>"public"
+        }
+      ]
+    }
+
+    it "increases event records" do
+      expect {
+        Event.insert_records(data)
+      }.to change(Event, :count).by(1)
+    end
+
+    it "sets fields correctly" do
+      Event.insert_records(data)
+      event = Event.last
+      expect(event.event_id).to eq "cqcpbnywjbqb"
+      expect(event.group_id).to eq 14429832
+    end
+
+    it "does not increase event record if event id already exists" do
+      create(:event, event_id: data[0]["id"])
+      expect {
+        Event.insert_records(data)
+      }.to_not change(Event, :count)
+    end
+
+    it "updates event record if event id already exists" do
+      event = create(:event, event_id: data[0]["id"], group_id: 1)
+      Event.insert_records(data)
+      event.reload
+      expect(event.group_id).to eq 14429832
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Event, type: :model do
       event = Event.last
       expect(event.event_id).to eq "cqcpbnywjbqb"
       expect(event.group_id).to eq 14429832
+      expect(event.time).to eq Time.utc(2017,6,13,2,0,0)
     end
 
     it "does not increase event record if event id already exists" do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Event, type: :model do
       expect(event.event_id).to eq "cqcpbnywjbqb"
       expect(event.group_id).to eq 14429832
       expect(event.time).to eq Time.utc(2017,6,13,2,0,0)
+      expect(event.group_urlname).to eq "Women-Who-Code-Silicon-Valley"
     end
 
     it "does not increase event record if event id already exists" do

--- a/spec/models/group_stat_spec.rb
+++ b/spec/models/group_stat_spec.rb
@@ -1,4 +1,15 @@
 RSpec.describe GroupStat, type: :model do
+  it "has a valid factory" do
+    group_stat = build(:group_stat)
+    expect(group_stat.valid?).to be true
+  end
+
+  it "has many events" do
+    group_stat = create(:group_stat)
+    event = create(:event, group_id: group_stat.group_id)
+    expect(group_stat.events.first).to eq event
+  end
+
   describe ".insert_records" do
     let(:data) {
       [


### PR DESCRIPTION
<!--- Which GitHub issue are you closing? -->
closes #3

<!--- What kinds of changes did you make? -->
## Description:
- Added event model
- Moved `insert_records` method to a concern
- Added rake task to import events data
- Removed requirement for options hash to be passed when initializing api

<!--- How did you test this? -->
<!--- How should someone else test this? -->
## QA:
- [ ] migrate database

- [ ] `bundle exec rake data_import:pro_group` to populate group stats records

- [ ] `bundle exec rake data_import:events` For each group in the group stats, pull event data.

- [ ] Choose an `Event` and get the `urlname` with the associated `GroupStat`. Run that URL specifically, for example: `bundle exec rake data_import:events['Women-Who-Code-Atlanta']`.  Note that the API request url that is formed should include the `scroll=since` parameter with the timestamp that matches the `time` field for the latest event in that group.


<!--- Any notes you'd like to include... -->
<!--- i.e. database migrations or deployment information. -->
## Notes:



@WomenWhoCode/meet-maynard-reviewers
