### PR TITLE
Collect paginated results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "http"
 gem 'standalone_migrations'
 gem 'bugsnag'
 gem 'pry'
+gem 'nitlink'
 
 group :development, :test do
   gem 'factory_girl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
     faker (1.7.3)
       i18n (~> 0.5)
     hashdiff (0.3.4)
+    hashwithindifferentaccess (0.1.1)
     http (2.2.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -59,6 +60,8 @@ GEM
     method_source (0.8.2)
     mini_portile2 (2.1.0)
     minitest (5.10.2)
+    nitlink (1.0.0)
+      hashwithindifferentaccess (~> 0.1.1)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     pg (0.20.0)
@@ -123,6 +126,7 @@ DEPENDENCIES
   factory_girl
   faker (~> 1.7)
   http
+  nitlink
   pg
   pry
   rspec

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,7 @@ require 'pg'
 require 'active_record'
 require 'yaml'
 require 'http'
+require 'nitlink/response'
 require 'erb'
 require 'bugsnag'
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,7 +2,6 @@ require 'pg'
 require 'active_record'
 require 'yaml'
 require 'http'
-require 'nitlink/response'
 require 'erb'
 require 'bugsnag'
 

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -11,5 +11,5 @@ development:
 test:
   <<: *default
   DATABASE_NAME: maynard_test
-  MEETUP_KEY: "real-key-not-needed"
+  MEETUP_KEY: "abcde01234" # real key not needed, but must be in hex format
   LOG_LEVEL: "WARN"

--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -1,4 +1,5 @@
 require 'rack'
+require 'nitlink/response'
 
 module Meetup
   class Api

--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -35,8 +35,8 @@ module Meetup
         { "errors" => [{"message": "Error parsing Meetup response"}] }
     end
 
-    def build_url(options=@options)
-      query_string = Rack::Utils.build_query(options)
+    def build_url
+      query_string = Rack::Utils.build_query(@options)
       "#{base_url}?#{query_string}"
     end
 
@@ -47,6 +47,11 @@ module Meetup
 
     def update_watermark
       @watermark.update(etag: @response.headers.get("etag").first)
+    end
+
+    def get_next_page(until_date=nil)
+      @url = pagination_link(until_date)
+      get_response if @url
     end
 
     protected
@@ -79,18 +84,26 @@ module Meetup
     private
 
     def do_request
-      url = build_url
-      MMLog.log.debug(url)
+      @url ||= build_url
+      MMLog.log.debug(@url)
 
       @watermark = Watermark.where(url: sanitized_url).first_or_create
       etag_str = %Q|#{@watermark.etag}|
-      HTTP.headers('If-None-Match' => "#{etag_str}").get(url)
+      HTTP.headers('If-None-Match' => "#{etag_str}").get(@url)
     end
 
     def sanitized_url
-      options_dup = @options.dup
-      options_dup.delete(:key)
-      build_url(options_dup)
+      @url.gsub(/key=[a-f0-9]+/,'key=sanitized')
+    end
+
+    def pagination_link(until_date)
+      target = @response.links.by_rel('next').try(:target)
+      return target.to_s if target && !until_date
+
+      if target && target.to_s =~ /scroll=since%3A(\d{4}-\d{2}-\d{2})/
+        since_date = Date.strptime($1, "%Y-%m-%d")
+        since_date < until_date ? target.to_s : nil
+      end
     end
   end
 end

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -5,7 +5,10 @@ namespace :data_import do
       group = args[:group].presence || 'womenwhocode'
       m = Meetup::Api.new(data_type: ["pro", group, "groups"], options: {})
       data = m.get_response
-      GroupStat.insert_records(data)
+      while data
+        GroupStat.insert_records(data)
+        data = m.get_next_page(Date.today)
+      end
 
     rescue Exception => e
       Bugsnag.notify(e)

--- a/spec/factories/watermarks.rb
+++ b/spec/factories/watermarks.rb
@@ -4,6 +4,6 @@ FactoryGirl.define do
       data_type ""
     end
 
-    url { "https://api.meetup.com/#{data_type}/?" }
+    url { "https://api.meetup.com/#{data_type}/?key=sanitized" }
   end
 end

--- a/spec/lib/meetup/api_spec.rb
+++ b/spec/lib/meetup/api_spec.rb
@@ -120,6 +120,47 @@ describe Meetup::Api do
     end
   end
 
+  context "#get_next_page" do
+    let(:response) do
+      [{
+        "id"=>12345,
+        "name"=>"Meetup Group Name",
+        "link"=>"https://www.meetup.com/Meetup-Group-Name/",
+      }]
+    end
+    let(:meetup_api) { Meetup::Api.new(data_type: [], options: {}) }
+
+    before do
+      meetup_request_link_stub
+      meetup_api.get_response
+    end
+
+    it "returns next page data" do
+      expect(meetup_api.get_next_page).to eq response
+    end
+
+    it "returns nil if date passed is earlier than since date in link" do
+      expect(meetup_api.get_next_page(Date.new(2017,5,1))).to be nil
+    end
+
+    it "returns nil if no remaining link header" do
+      meetup_api.get_next_page
+      expect(meetup_api.get_next_page).to be nil
+    end
+
+    it "sets remaining_requests and reset_seconds values" do
+      meetup_api.get_next_page
+      expect(meetup_api.remaining_requests).to eq 29
+      expect(meetup_api.reset_seconds).to eq 10
+    end
+
+    it "creates watermark if none is set" do
+      expect{
+        meetup_api.get_next_page
+      }.to change(Watermark, :count).by(1)
+    end
+  end
+
   context "#throttle_wait" do
     let(:meetup_api) { Meetup::Api.new(data_type: [], options: {}) }
 

--- a/spec/support/webmocks.rb
+++ b/spec/support/webmocks.rb
@@ -11,4 +11,22 @@ module Webmocks
     stub_request(:get, Regexp.new(Meetup::Api::BASE_URI))
     .to_return(status: 304)
   end
+
+  def meetup_request_link_stub(remaining: 29, reset: 10)
+    stub_request(:get, Regexp.new(Meetup::Api::BASE_URI))
+    .to_return(body: response.to_json, status: 200,
+               headers: {"Etag" => "abc",
+                         "X-Ratelimit-Remaining"=>"#{remaining}",
+                         "X-Ratelimit-Reset"=>"#{reset}",
+                         "Link" => %Q|<https://api.meetup.com/some-url/events?key=abcde&scroll=since%3A2017-06-01T06%3A00%3A00.000-07%3A00>; rel="next"|}).then
+    .to_return(body: response.to_json, status: 200,
+               headers: {"Etag" => "abc",
+                         "X-Ratelimit-Remaining"=>"#{remaining}",
+                         "X-Ratelimit-Reset"=>"#{reset}",
+                         "Link" => "<https://api.meetup.com/some-url/events?key=abcde&scroll=since%3A2018-06-01T06%3A00%3A00.000-07%3A00>; rel='next'"}).then
+    .to_return(body: response.to_json, status: 200,
+               headers: {"Etag" => "abc",
+                         "X-Ratelimit-Remaining"=>"#{remaining}",
+                         "X-Ratelimit-Reset"=>"#{reset}"})
+  end
 end


### PR DESCRIPTION
<!--- Which GitHub issue are you closing? -->
closes #26 

<!--- What kinds of changes did you make? -->
## Description:
- Add a `get_text_page` method which retrieves the next page of results from the response.

<!--- How did you test this? -->
<!--- How should someone else test this? -->
## QA:
- [x] In console:
```
> m = Meetup::Api.new(data_type: ['Women-Who-Code-Silicon-Valley','events'], options: {})
> records = m.get_response
```

Then repeatedly until you get no results:
```
> next_page = m.get_next_page(Date.new(2022,1,1))
```

Verify that the `scroll=since` date is earlier than the date passed to the `get_next_page` method.

<!--- Any notes you'd like to include... -->
<!--- i.e. database migrations or deployment information. -->
## Notes:
[The docs](https://www.meetup.com/meetup_api/docs/:urlname/events/#list) say the default number of records it will return per page is 200, but I'm only getting 29 returned for the first hit, then around 11 or 12 for each subsequent page.  Tested in Postman and getting same results.  Not sure what is up with that, will poke around a bit more.


@WomenWhoCode/meet-maynard-reviewers
