### PR TITLE
pull rsvp question data from meetup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,5 +82,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :shell, privileged: false, inline:<<-SHELL
     cd /vagrant
     bundler install
+    bundle exec rake db:setup
   SHELL
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,12 @@ class Event < ActiveRecord::Base
   include Retrievable
 
   belongs_to :group, class_name: "GroupStat", primary_key: :group_id
+  has_many :rsvp_questions,
+    class_name: "RSVPQuestion",
+    primary_key: :event_id,
+    foreign_key: :event_id
+
+  scope :without_rsvp, -> { includes(:rsvp_questions).where(rsvp_questions: {id: nil}) }
 
   class << self
     def meetup_primary_key

--- a/app/models/rsvp_question.rb
+++ b/app/models/rsvp_question.rb
@@ -1,0 +1,41 @@
+class RSVPQuestion < ActiveRecord::Base
+  include Retrievable
+
+  belongs_to :event, class_name: "Event", primary_key: :event_id
+
+  class << self
+    def retrieve_answers(event)
+        m = Meetup::Api.new(
+              data_type: [event.group_urlname, "events", event.event_id, "rsvps"],
+              options: {fields: "answers"}
+            )
+
+        meetup_data = m.get_response
+        while meetup_data && meetup_data.any?
+          meetup_data.each do |data|
+            RSVPQuestion.create_from_answers(data)
+          end
+
+          meetup_data = m.get_next_page(Date.today)
+        end
+
+      rescue => e
+        Bugsnag.notify(e, event_id: event.id)
+    end
+
+    def create_from_answers(data)
+      return nil unless data["answers"] && data["answers"].any?
+
+      fields = {
+        event_id: data["event"]["id"],
+        group_urlname: data["group"]["urlname"],
+        member_id: data["member"]["id"],
+      }
+
+      data["answers"].each do |ans|
+        ans.delete("updated")
+        RSVPQuestion.find_or_create_by(fields.merge(ans))
+      end
+    end
+  end
+end

--- a/app/models/rsvp_question.rb
+++ b/app/models/rsvp_question.rb
@@ -11,7 +11,7 @@ class RSVPQuestion < ActiveRecord::Base
             )
 
         meetup_data = m.get_response
-        while meetup_data && meetup_data.any?
+        while !meetup_data.blank?
           meetup_data.each do |data|
             RSVPQuestion.create_from_answers(data)
           end
@@ -24,7 +24,7 @@ class RSVPQuestion < ActiveRecord::Base
     end
 
     def create_from_answers(data)
-      return nil unless data["answers"] && data["answers"].any?
+      return nil if data["answers"].blank?
 
       fields = {
         event_id: data["event"]["id"],
@@ -33,6 +33,7 @@ class RSVPQuestion < ActiveRecord::Base
       }
 
       data["answers"].each do |ans|
+        next if ans["answer"].blank?
         ans.delete("updated")
         RSVPQuestion.find_or_create_by(fields.merge(ans))
       end

--- a/db/migrate/20170627051832_create_rsvp_questions.rb
+++ b/db/migrate/20170627051832_create_rsvp_questions.rb
@@ -1,0 +1,14 @@
+class CreateRsvpQuestions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :rsvp_questions do |t|
+      t.string :event_id
+      t.integer :question_id
+      t.string :question
+      t.string :answer
+      t.integer :member_id
+      t.string :group_urlname
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170621200414) do
+ActiveRecord::Schema.define(version: 20170627051832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,17 @@ ActiveRecord::Schema.define(version: 20170621200414) do
     t.float "gender_male", default: 0.0
     t.float "gender_other", default: 0.0
     t.string "status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "rsvp_questions", force: :cascade do |t|
+    t.string "event_id"
+    t.integer "question_id"
+    t.string "question"
+    t.string "answer"
+    t.integer "member_id"
+    t.string "group_urlname"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,16 @@
+group = GroupStat.first_or_create(
+  group_id: 14429832,
+  name: "Women Who Code Silicon Valley",
+  urlname: "Women-Who-Code-Silicon-Valley"
+)
+
+event_data = [
+  {
+    event_id: "kxmpklytmbnc",
+    time: "2015-10-01 01:30:00 UTC"
+  },
+]
+
+event_data.each do |event|
+  Event.find_or_create_by(event.merge(group_id: group.group_id, group_urlname: group.urlname))
+end

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -24,4 +24,14 @@ namespace :data_import do
       Event.retrieve_events(group_stat)
     end
   end
+
+  desc "pull rsvp data. Usage: rake data_import:rsvps['Women-Who-Code-Silicon-Valley']"
+  task :rsvps, [:urlname] do |t, args|
+    scope = args[:urlname].present? ? Event.where(group_urlname: args[:urlname]) : Event.all
+
+    scope.find_each do |event|
+      next unless event.group_urlname.present?
+      RSVPQuestion.retrieve_answers(event)
+    end
+  end
 end

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -27,7 +27,11 @@ namespace :data_import do
 
   desc "pull rsvp data. Usage: rake data_import:rsvps['Women-Who-Code-Silicon-Valley']"
   task :rsvps, [:urlname] do |t, args|
-    scope = args[:urlname].present? ? Event.where(group_urlname: args[:urlname]) : Event.all
+    if args[:urlname].present?
+      scope = Event.without_rsvp.where(group_urlname: args[:urlname])
+    else
+      scope = Event.without_rsvp
+    end
 
     scope.find_each do |event|
       next unless event.group_urlname.present?

--- a/spec/factories/rsvp_questions.rb
+++ b/spec/factories/rsvp_questions.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :rsvp_question, class: RSVPQuestion do
+    event_id { Faker::Lorem.characters(12) }
+    group_urlname "Women-Who-Code-Silicon-Valley"
+  end
+end

--- a/spec/models/rsvp_question_spec.rb
+++ b/spec/models/rsvp_question_spec.rb
@@ -1,0 +1,125 @@
+RSpec.describe RSVPQuestion, type: :model do
+  it "has a valid factory" do
+    rsvp_question = build(:rsvp_question)
+    expect(rsvp_question.valid?).to be true
+  end
+
+  it "belongs to an event" do
+    event = create(:event)
+    rsvp_question = create(:rsvp_question, event_id: event.event_id)
+    expect(rsvp_question.event).to eq event
+  end
+
+  let(:data) {
+    [
+      {
+        "created" => 1497990769000,
+        "updated" => 1497990769000,
+        "response" => "yes",
+        "guests" => 0,
+        "event" =>
+        {
+          "id" => "dkxpgnywjbdc",
+          "name" => "iOS Beginner Series: Intro to iOS & Swift",
+          "yes_rsvp_count" => 71,
+          "time" => 1498181400000,
+          "utc_offset" => -25200000
+        },
+        "group" =>
+        {
+          "id" => 14429832,
+          "urlname" => "Women-Who-Code-Silicon-Valley",
+          "name" => "Women Who Code Silicon Valley",
+          "who" => "Coders",
+          "members" => 3858,
+          "join_mode" => "open",
+          "group_photo" =>
+          {
+            "id" => 431687379,
+            "highres_link" => "https://secure.meetupstatic.com/photos/event/b/9/1/3/highres_431687379.jpeg",
+            "photo_link" => "https://secure.meetupstatic.com/photos/event/b/9/1/3/600_431687379.jpeg",
+            "thumb_link" => "https://secure.meetupstatic.com/photos/event/b/9/1/3/thumb_431687379.jpeg",
+            "type" => "event",
+            "base_url" => "https://secure.meetupstatic.com"
+          }
+        },
+        "member" =>
+        {
+          "id" => Faker::Number.number(5),
+          "name" => Faker::StarWars.character,
+          "event_context" => {"host" => false}
+        },
+        "venue" =>
+        {
+          "id" => 24949344,
+          "name" => "Coding Dojo",
+          "lat" => 37.37540054321289,
+          "lon" => -121.91015625,
+          "repinned" => false,
+          "address_1" => "1920 Zanker Rd #20",
+          "city" => "San Jose",
+          "country" => "us",
+          "localized_country_name" => "USA",
+          "zip" => "",
+          "state" => "CA"
+        },
+        "answers" =>
+        [
+          {
+            "answer" => Faker::StarWars.wookie_sentence,
+            "question_id" => Faker::Number.number(5).to_i,
+            "question" => Faker::StarWars.quote,
+            "updated" => 1497990769000
+          }
+        ]
+      }
+    ]
+  }
+
+  describe ".create_from_answers" do
+    it "increases rsvp_question records" do
+      expect {
+        RSVPQuestion.create_from_answers(data[0])
+      }.to change(RSVPQuestion, :count).by(1)
+    end
+
+    it "sets fields correctly" do
+      row = data[0]
+      RSVPQuestion.create_from_answers(row)
+      rsvp_question = RSVPQuestion.last
+      expect(rsvp_question.event_id).to eq row["event"]["id"]
+      expect(rsvp_question.group_urlname).to eq row["group"]["urlname"]
+      expect(rsvp_question.question).to eq row["answers"][0]["question"]
+      expect(rsvp_question.question_id).to eq row["answers"][0]["question_id"]
+      expect(rsvp_question.answer).to eq row["answers"][0]["answer"]
+    end
+
+    it "does not increase rsvp_question record if it already exists" do
+      RSVPQuestion.create_from_answers(data[0])
+      expect {
+        RSVPQuestion.create_from_answers(data[0])
+      }.to_not change(RSVPQuestion, :count)
+    end
+
+    it "skips rsvp_question record if answer is not provided" do
+      row = data[0]
+      row.delete("answers")
+      expect {
+        RSVPQuestion.create_from_answers(row)
+      }.to_not change(RSVPQuestion, :count)
+    end
+  end
+
+  describe ".retrieve_answers" do
+    let(:response) { data }
+    before do
+      meetup_request_success_stub
+    end
+
+    it "increases rsvp_question records" do
+      expect {
+        RSVPQuestion.retrieve_answers(build(:event))
+      }.to change(RSVPQuestion, :count).by(1)
+    end
+  end
+end

--- a/spec/models/rsvp_question_spec.rb
+++ b/spec/models/rsvp_question_spec.rb
@@ -101,9 +101,17 @@ RSpec.describe RSVPQuestion, type: :model do
       }.to_not change(RSVPQuestion, :count)
     end
 
-    it "skips rsvp_question record if answer is not provided" do
+    it "skips rsvp_question record if answer is not included in response" do
       row = data[0]
       row.delete("answers")
+      expect {
+        RSVPQuestion.create_from_answers(row)
+      }.to_not change(RSVPQuestion, :count)
+    end
+
+    it "skips rsvp_question record if answer provided is blank" do
+      row = data[0]
+      row["answers"][0]["answer"] = ""
       expect {
         RSVPQuestion.create_from_answers(row)
       }.to_not change(RSVPQuestion, :count)


### PR DESCRIPTION
<!--- Which GitHub issue are you closing? -->
closes #2 

<!--- What kinds of changes did you make? -->
## Description:
- Using the Meetup Event RSVP endpoint, grabs question and answer data and inserts it into the database

<!--- How did you test this? -->
<!--- How should someone else test this? -->
## QA:
- [ ] Run tests: `heroku run bundle exec rspec `
- [x] Run rake task, which uses the seed data to grab RSVP questions: `heroku run bundle exec rake data_import:rsvps`
- [x] Examine RSVP data in the console: `heroku run pry`


<!--- Any notes you'd like to include... -->
<!--- i.e. database migrations or deployment information. -->
## Notes:

On staging I guess we'll need to run migrations:
- [ ] `heroku run bundle exec rake db:migrate`

@WomenWhoCode/meet-maynard-reviewers
