### PR TITLE
move Meetup API object handling out of models

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,28 +14,15 @@ class Event < ActiveRecord::Base
       :event_id
     end
 
-    def retrieve_events(group_stat)
-      begin
-        last_event_time = group_stat.events.order(time: :desc).first.try(:time)
-
-        if last_event_time
-          since_time = I18n.l last_event_time, format: :meetup_scroll_since
-          options = { scroll: "since:#{since_time}" }
-          m = Meetup::Api.new(data_type: [group_stat.urlname, "events"],
-                              options: options)
-        else
-          m = Meetup::Api.new(data_type: [group_stat.urlname, "events"])
-        end
-
+    def retrieve_events(group_stat, m)
         data = m.get_response
-        while data && data.any?
+        while data.present?
           Event.insert_records(data)
           data = m.get_next_page(Date.today)
         end
 
-      rescue Exception => e
+      rescue => e
         Bugsnag.notify(e, group_id: group_stat.id)
-      end
     end
   end
 end

--- a/app/models/group_stat.rb
+++ b/app/models/group_stat.rb
@@ -8,4 +8,15 @@ class GroupStat < ActiveRecord::Base
       :group_id
     end
   end
+
+  def get_last_event_time_option
+    last_event_time = events.order(time: :desc).first.try(:time)
+
+    if last_event_time
+      since_time = I18n.l last_event_time, format: :meetup_scroll_since
+      options = { scroll: "since:#{since_time}" }
+    else
+      {}
+    end
+  end
 end

--- a/app/models/rsvp_question.rb
+++ b/app/models/rsvp_question.rb
@@ -4,14 +4,9 @@ class RSVPQuestion < ActiveRecord::Base
   belongs_to :event, class_name: "Event", primary_key: :event_id
 
   class << self
-    def retrieve_answers(event)
-        m = Meetup::Api.new(
-              data_type: [event.group_urlname, "events", event.event_id, "rsvps"],
-              options: {fields: "answers"}
-            )
-
+    def retrieve_answers(event, m)
         meetup_data = m.get_response
-        while !meetup_data.blank?
+        while meetup_data.present?
           meetup_data.each do |data|
             RSVPQuestion.create_from_answers(data)
           end

--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -62,6 +62,13 @@ module Meetup
       get_response if @url
     end
 
+    def reset_data_options(data_type:, options: {})
+      @data_type = data_type
+      @options = options
+      @options[:key] = ENV['MEETUP_KEY']
+      @url = build_url
+    end
+
     protected
 
     def base_url

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -19,9 +19,15 @@ namespace :data_import do
   task :events, [:urlname] do |t, args|
     scope = args[:urlname].present? ? GroupStat.where(urlname: args[:urlname]) : GroupStat.all
 
+    meetup_api = Meetup::Api.new(data_type: [])
     scope.find_each do |group_stat|
       next unless group_stat.urlname.present?
-      Event.retrieve_events(group_stat)
+
+      meetup_api.reset_data_options(
+        data_type: [group_stat.urlname, "events"],
+        options: group_stat.get_last_event_time_option
+      )
+      Event.retrieve_events(group_stat, meetup_api)
     end
   end
 
@@ -33,9 +39,15 @@ namespace :data_import do
       scope = Event.without_rsvp
     end
 
+    meetup_api = Meetup::Api.new(data_type: [])
     scope.find_each do |event|
       next unless event.group_urlname.present?
-      RSVPQuestion.retrieve_answers(event)
+
+      meetup_api.reset_data_options(
+        data_type: [event.group_urlname, "events", event.event_id, "rsvps"],
+        options: {fields: "answers"}
+      )
+      RSVPQuestion.retrieve_answers(event, meetup_api)
     end
   end
 end

--- a/spec/lib/meetup/api_spec.rb
+++ b/spec/lib/meetup/api_spec.rb
@@ -177,4 +177,15 @@ describe Meetup::Api do
       meetup_api.throttle_wait
     end
   end
+
+  context '#reset_data_options' do
+    let(:meetup_api) { Meetup::Api.new(data_type: ['cat'], options: {foo: 'bar'}) }
+
+    it 'sets new url data after calling reset' do
+      meetup_api.build_url
+      meetup_api.reset_data_options(data_type: ['dog'])
+      expect(meetup_api.build_url).to_not include('cat', 'foo=bar')
+      expect(meetup_api.build_url).to include('dog')
+    end
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -77,19 +77,15 @@ RSpec.describe Event, type: :model do
 
   describe ".retrieve_events" do
     let(:response) { data }
+    let(:meetup_api) { Meetup::Api.new(data_type: ['foo']) }
     before do
       meetup_request_success_stub
     end
 
-    it "does not pass scroll parameter if no events" do
-      expect(Meetup::Api).to receive(:new).with(data_type: [group_stat.urlname, "events"]).and_return(Meetup::Api.new(data_type: []))
-      Event.retrieve_events(group_stat)
-    end
-
-    it "passes scroll parameter if events exist" do
-      create(:event, time: Time.utc(2017,6,19,10,28,14), group_id: group_stat.group_id)
-      expect(Meetup::Api).to receive(:new).with(data_type: [group_stat.urlname, "events"], options: { scroll: "since:2017-06-19T10:28:14.000-00:00" } ).and_return(Meetup::Api.new(data_type: []))
-      Event.retrieve_events(group_stat)
+    it "increases event records" do
+      expect {
+        Event.retrieve_events(build(:group_stat), meetup_api)
+      }.to change(Event, :count).by(1)
     end
   end
 end

--- a/spec/models/group_stat_spec.rb
+++ b/spec/models/group_stat_spec.rb
@@ -96,4 +96,19 @@ RSpec.describe GroupStat, type: :model do
       expect(group_stat.past_events).to eq 5
     end
   end
+
+  describe "#get_last_event_time_option" do
+    let(:group_stat) { create(:group_stat) }
+
+    it "does not return scroll parameter if no events" do
+      expect(group_stat.get_last_event_time_option).to eq Hash.new
+    end
+
+    it "returns scroll parameter if events exist" do
+      create(:event, time: Time.utc(2017,6,19,10,28,14), group_id: group_stat.group_id)
+      expect(group_stat.get_last_event_time_option).to eq(
+        { scroll: "since:2017-06-19T10:28:14.000-00:00" }
+      )
+    end
+  end
 end

--- a/spec/models/rsvp_question_spec.rb
+++ b/spec/models/rsvp_question_spec.rb
@@ -120,13 +120,14 @@ RSpec.describe RSVPQuestion, type: :model do
 
   describe ".retrieve_answers" do
     let(:response) { data }
+    let(:meetup_api) { Meetup::Api.new(data_type: ['foo']) }
     before do
       meetup_request_success_stub
     end
 
     it "increases rsvp_question records" do
       expect {
-        RSVPQuestion.retrieve_answers(build(:event))
+        RSVPQuestion.retrieve_answers(build(:event), meetup_api)
       }.to change(RSVPQuestion, :count).by(1)
     end
   end


### PR DESCRIPTION
<!--- Which GitHub issue are you closing? -->
closes #35 

<!--- What kinds of changes did you make? -->
## Description:
- Try to avoid the throttling bug by creating the API object once so we can retain the last known header data for rate limits.

<!--- How did you test this? -->
<!--- How should someone else test this? -->
## QA:
To test if there are no more throttling errors, you'll have to add a lot of data. For each of these, you should see the URL change in the debug output when it makes new requests. Also, it will occasionally pause for short periods of time. You should not see errors in Bugsnag for throttling or anything else.
- [ ] Get a bunch of events: `heroku run bundle exec rake data_import:events`
- [ ] Get a bunch of RSVPs: `heroku run bundle exec rake data_import:rsvps`

<!--- Any notes you'd like to include... -->
<!--- i.e. database migrations or deployment information. -->
## Notes:

n/a


@WomenWhoCode/meet-maynard-reviewers
