### PR TITLE
sanitize url for logging

### DIFF
--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -100,7 +100,7 @@ module Meetup
 
     def do_request
       @url ||= build_url
-      MMLog.log.debug(@url)
+      MMLog.log.debug(sanitized_url)
 
       @watermark = Watermark.where(url: sanitized_url).first_or_create
       etag_str = %Q|#{@watermark.etag}|


### PR DESCRIPTION
<!--- Which GitHub issue are you closing? -->
closes #30 

<!--- What kinds of changes did you make? -->
## Description:
- One of the logged urls wasn't being sanitized. 

<!--- How did you test this? -->
<!--- How should someone else test this? -->
## QA:
Login to the console with `heroku run pry`
- [ ] Run `Meetup::Api.new(data_type: ['Women-Who-Code-Silicon-Valley']).get_response`. URL output should not have the key

<!--- Any notes you'd like to include... -->
<!--- i.e. database migrations or deployment information. -->
## Notes:

After this is is merged to master and released, we should change the Meetup API key again.

@WomenWhoCode/meet-maynard-reviewers
