### PR TITLE
Only run RSVP answers task once per event

### DIFF
--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -69,6 +69,10 @@ module Meetup
       @url = build_url
     end
 
+    def sanitized_url
+      @url.gsub(/key=[a-f0-9]+/,'key=sanitized')
+    end
+
     protected
 
     def base_url
@@ -105,10 +109,6 @@ module Meetup
       @watermark = Watermark.where(url: sanitized_url).first_or_create
       etag_str = %Q|#{@watermark.etag}|
       HTTP.headers('If-None-Match' => "#{etag_str}").get(@url)
-    end
-
-    def sanitized_url
-      @url.gsub(/key=[a-f0-9]+/,'key=sanitized')
     end
 
     def pagination_link(until_date)

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -47,7 +47,8 @@ namespace :data_import do
         data_type: [event.group_urlname, "events", event.event_id, "rsvps"],
         options: {fields: "answers"}
       )
-      RSVPQuestion.retrieve_answers(event, meetup_api)
+      watermark = Watermark.where(url: meetup_api.sanitized_url).first
+      RSVPQuestion.retrieve_answers(event, meetup_api) unless watermark
     end
   end
 end


### PR DESCRIPTION
<!--- Which GitHub issue are you closing? -->
closes #39 

<!--- What kinds of changes did you make? -->
## Description:
- checks if watermark exists before making the api call for an RSVP event

<!--- How did you test this? -->
<!--- How should someone else test this? -->
## QA:
- [x] Run: `bundle exec rake data_import:rsvps['Women-Who-Code-Silicon-Valley']`. There should be log output for the API calls, though I am not seeing it locally anymore -- is anyone else having issues?  I had to add a `puts` statement in the `do_request` method.  Check database to make sure watermarks have been filled in. 

 - [x] Run: `bundle exec rake data_import:rsvps['Women-Who-Code-Silicon-Valley']`. There should be no log output with API calls.



<!--- Any notes you'd like to include... -->
<!--- i.e. database migrations or deployment information. -->
## Notes:



@WomenWhoCode/meet-maynard-reviewers
