### PR TITLE
Create/update watermark only on successful response

### DIFF
--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -27,7 +27,6 @@ module Meetup
         return {}
       else
         set_throttle_values
-        update_watermark
         get_body
       end
 
@@ -89,6 +88,7 @@ module Meetup
       body = @response.parse(:json)
 
       if response_success?
+        update_watermark
         body
       else
         errors = body["errors"] || [{"message": "Meetup response has no body"}]
@@ -106,7 +106,7 @@ module Meetup
       @url ||= build_url
       MMLog.log.debug(sanitized_url)
 
-      @watermark = Watermark.where(url: sanitized_url).first_or_create
+      @watermark = Watermark.where(url: sanitized_url).first_or_initialize
       etag_str = %Q|#{@watermark.etag}|
       HTTP.headers('If-None-Match' => "#{etag_str}").get(@url)
     end

--- a/spec/lib/meetup/api_spec.rb
+++ b/spec/lib/meetup/api_spec.rb
@@ -110,12 +110,19 @@ describe Meetup::Api do
     end
 
     context "invalid request" do
-      it 'notifies Bugsnag on error' do
-        stub_request(:get, Regexp.new(Meetup::Api::BASE_URI))
-        .to_return(body: '{}', status: 404, headers: {})
+      before do
+        meetup_request_error_stub
+      end
 
+      it 'notifies Bugsnag on error' do
         expect(Bugsnag).to receive(:notify).once
         expect(meetup_api.get_response).to eq Hash.new
+      end
+
+      it "does not create watermark" do
+        expect{
+          meetup_api.get_response
+        }.to_not change(Watermark, :count)
       end
     end
   end

--- a/spec/support/webmocks.rb
+++ b/spec/support/webmocks.rb
@@ -7,6 +7,11 @@ module Webmocks
                          "X-Ratelimit-Reset"=>"#{reset}"})
   end
 
+  def meetup_request_error_stub
+    stub_request(:get, Regexp.new(Meetup::Api::BASE_URI))
+    .to_return(body: '{}', status: 404, headers: {})
+  end
+
   def meetup_request_not_modified_stub
     stub_request(:get, Regexp.new(Meetup::Api::BASE_URI))
     .to_return(status: 304)


### PR DESCRIPTION
<!--- Which GitHub issue are you closing? -->
closes #43

<!--- What kinds of changes did you make? -->
## Description:
- Moves the updating of the watermark to be in the success block of checking the response
- Only initializes the watermark instead of creating for new api runs


<!--- How did you test this? -->
<!--- How should someone else test this? -->
## QA:
- [x] Run `heroku run rake data_import:pro_group -a wwcode-maynard-staging-pr-44`. Note that watermark records are created.

- [x] Run `heroku run rake data_import:pro_group['foo'] -a wwcode-maynard-staging-pr-44`. Note that no new watermark is created.

<!--- Any notes you'd like to include... -->
<!--- i.e. database migrations or deployment information. -->
## Notes:



@WomenWhoCode/meet-maynard-reviewers
