### PR TITLE
fix Bugsnag error grouping for API errors

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,6 +21,10 @@
     "BUGSNAG_KEY": {
       "description": "The key required to communicate with the Bugsnag API",
       "required": true
+    },
+    "HEROKU_APP_NAME": {
+      "description": "Set by Heroku to the name of this review app",
+      "required": true
     }
   },
   "formation": {

--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -33,6 +33,7 @@ module Meetup
 
       rescue => e
         Bugsnag.notify("Error parsing Meetup response: #{e}") do |notification|
+          notification.grouping_hash = e.class.to_s + e.message
           notification.add_tab(:meetup, {
             request_url: sanitized_url,
             response: @response.to_a,


### PR DESCRIPTION
<!--- Which GitHub issue are you closing? -->
closes #40 

<!--- What kinds of changes did you make? -->
## Description:
- Updates the Bugsnag error grouping for Meetup API exceptions to use the Exception message. This means the errors will be separated by unique exceptions:
<img width="460" alt="screen shot 2017-08-08 at 12 10 34 pm" src="https://user-images.githubusercontent.com/7094373/29089916-c61bc7be-7c32-11e7-8119-2608123d3092.png">
- Also tracks the review app name so that Bugsnag errors from review apps don't say "production".

<!--- How did you test this? -->
<!--- How should someone else test this? -->
## QA:
Open a console in the review app: `heroku run pry -a wwcode-maynard-staging-pr-45`
- [x] Generate a bad url and see a Bugsnag error message about it: `Meetup::Api.new(data_type: ["Bad-Group-Name"]).get_response`
- [x] Add a couple bad events to the database
- [x] Run the rake task `heroku run bundle exec bundle exec rake data_import:rsvps["Women-Who-Code-Silicon-Valley"] -a wwcode-maynard-staging-pr-45` and you should see one Bugsnag error for multiple bad events: "Error parsing Meetup response: invalid event"

<!--- Any notes you'd like to include... -->
<!--- i.e. database migrations or deployment information. -->
## Notes:

- [ ] After this is released to production, you can close issue #32 


@WomenWhoCode/meet-maynard-reviewers
