### PR TITLE
Monitoring heroku rake tasks

### DIFF
--- a/app.json
+++ b/app.json
@@ -30,7 +30,8 @@
   "formation": {
   },
   "addons": [
-    "heroku-postgresql"
+    "heroku-postgresql",
+    "papertrail"
   ],
   "buildpacks": [
     {

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -1,6 +1,7 @@
 namespace :data_import do
   desc "pull pro group data. Usage: rake data_import:pro_group['groupname']"
   task :pro_group, [:group] do |t, args|
+    MMLog.log.debug "START data_import:pro_group"
     begin
       group = args[:group].presence || 'womenwhocode'
       m = Meetup::Api.new(data_type: ["pro", group, "groups"])
@@ -13,10 +14,12 @@ namespace :data_import do
     rescue Exception => e
       Bugsnag.notify(e)
     end
+    MMLog.log.debug "END data_import:pro_group"
   end
 
   desc "pull event data. Usage: rake data_import:events['Women-Who-Code-Silicon-Valley']"
   task :events, [:urlname] do |t, args|
+    MMLog.log.debug "START data_import:events"
     scope = args[:urlname].present? ? GroupStat.where(urlname: args[:urlname]) : GroupStat.all
 
     meetup_api = Meetup::Api.new(data_type: [])
@@ -29,10 +32,12 @@ namespace :data_import do
       )
       Event.retrieve_events(group_stat, meetup_api)
     end
+    MMLog.log.debug "END data_import:events"
   end
 
   desc "pull rsvp data. Usage: rake data_import:rsvps['Women-Who-Code-Silicon-Valley']"
   task :rsvps, [:urlname] do |t, args|
+    MMLog.log.debug "START data_import:rsvps"
     if args[:urlname].present?
       scope = Event.without_rsvp.where(group_urlname: args[:urlname])
     else
@@ -50,5 +55,6 @@ namespace :data_import do
       watermark = Watermark.where(url: meetup_api.sanitized_url).first
       RSVPQuestion.retrieve_answers(event, meetup_api) unless watermark
     end
+    MMLog.log.debug "END data_import:rsvps"
   end
 end

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -1,7 +1,7 @@
 namespace :data_import do
   desc "pull pro group data. Usage: rake data_import:pro_group['groupname']"
   task :pro_group, [:group] do |t, args|
-    MMLog.log.debug "START data_import:pro_group"
+    MMLog.log.debug("START data_import:pro_group")
     begin
       group = args[:group].presence || 'womenwhocode'
       m = Meetup::Api.new(data_type: ["pro", group, "groups"])
@@ -14,12 +14,12 @@ namespace :data_import do
     rescue Exception => e
       Bugsnag.notify(e)
     end
-    MMLog.log.debug "END data_import:pro_group"
+    MMLog.log.debug("END data_import:pro_group")
   end
 
   desc "pull event data. Usage: rake data_import:events['Women-Who-Code-Silicon-Valley']"
   task :events, [:urlname] do |t, args|
-    MMLog.log.debug "START data_import:events"
+    MMLog.log.debug("START data_import:events")
     scope = args[:urlname].present? ? GroupStat.where(urlname: args[:urlname]) : GroupStat.all
 
     meetup_api = Meetup::Api.new(data_type: [])
@@ -32,12 +32,12 @@ namespace :data_import do
       )
       Event.retrieve_events(group_stat, meetup_api)
     end
-    MMLog.log.debug "END data_import:events"
+    MMLog.log.debug("END data_import:events")
   end
 
   desc "pull rsvp data. Usage: rake data_import:rsvps['Women-Who-Code-Silicon-Valley']"
   task :rsvps, [:urlname] do |t, args|
-    MMLog.log.debug "START data_import:rsvps"
+    MMLog.log.debug("START data_import:rsvps")
     if args[:urlname].present?
       scope = Event.without_rsvp.where(group_urlname: args[:urlname])
     else
@@ -55,6 +55,6 @@ namespace :data_import do
       watermark = Watermark.where(url: meetup_api.sanitized_url).first
       RSVPQuestion.retrieve_answers(event, meetup_api) unless watermark
     end
-    MMLog.log.debug "END data_import:rsvps"
+    MMLog.log.debug("END data_import:rsvps")
   end
 end


### PR DESCRIPTION
<!--- Which GitHub issue are you closing? -->
closes #41 

<!--- What kinds of changes did you make? -->
## Description:
- Added START/END statements that are easily searchable in the Papertrail logs.  Using the `heroku.scheduler.XXX` doesn't work very well because the scheduler ID changes every time it runs.

- Added Papertrail to the add-ons that the review app should launch.



<!--- How did you test this? -->
<!--- How should someone else test this? -->
## QA:
- [ ] Set up a test alert that Papertrail sent successfully when it didn't hear from the cron after an hour (just used an hour as a test interval).
- [ ] remove snitch addon

<!--- Any notes you'd like to include... -->
<!--- i.e. database migrations or deployment information. -->
## Notes:

cc: @WomenWhoCode/website-reviewers 


