### PR TITLE
Only check for next page if response was successful

### DIFF
--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -113,12 +113,14 @@ module Meetup
     end
 
     def pagination_link(until_date)
-      target = @response.links.by_rel('next').try(:target)
-      return target.to_s if target && !until_date
+      if response_success?
+        target = @response.links.by_rel('next').try(:target)
+        return target.to_s if target && !until_date
 
-      if target && target.to_s =~ /scroll=since%3A(\d{4}-\d{2}-\d{2})/
-        since_date = Date.strptime($1, "%Y-%m-%d")
-        since_date < until_date ? target.to_s : nil
+        if target && target.to_s =~ /scroll=since%3A(\d{4}-\d{2}-\d{2})/
+          since_date = Date.strptime($1, "%Y-%m-%d")
+          since_date < until_date ? target.to_s : nil
+        end
       end
     end
   end

--- a/spec/lib/meetup/api_spec.rb
+++ b/spec/lib/meetup/api_spec.rb
@@ -137,34 +137,45 @@ describe Meetup::Api do
     end
     let(:meetup_api) { Meetup::Api.new(data_type: [], options: {}) }
 
-    before do
-      meetup_request_link_stub
-      meetup_api.get_response
-    end
+    context "with valid response" do
+      before do
+        meetup_request_link_stub
+        meetup_api.get_response
+      end
 
-    it "returns next page data" do
-      expect(meetup_api.get_next_page).to eq response
-    end
+      it "returns next page data" do
+        expect(meetup_api.get_next_page).to eq response
+      end
 
-    it "returns nil if date passed is earlier than since date in link" do
-      expect(meetup_api.get_next_page(Date.new(2017,5,1))).to be nil
-    end
+      it "returns nil if date passed is earlier than since date in link" do
+        expect(meetup_api.get_next_page(Date.new(2017,5,1))).to be nil
+      end
 
-    it "returns nil if no remaining link header" do
-      meetup_api.get_next_page
-      expect(meetup_api.get_next_page).to be nil
-    end
-
-    it "sets remaining_requests and reset_seconds values" do
-      meetup_api.get_next_page
-      expect(meetup_api.remaining_requests).to eq 29
-      expect(meetup_api.reset_seconds).to eq 10
-    end
-
-    it "creates watermark if none is set" do
-      expect{
+      it "returns nil if no remaining link header" do
         meetup_api.get_next_page
-      }.to change(Watermark, :count).by(1)
+        expect(meetup_api.get_next_page).to be nil
+      end
+
+      it "sets remaining_requests and reset_seconds values" do
+        meetup_api.get_next_page
+        expect(meetup_api.remaining_requests).to eq 29
+        expect(meetup_api.reset_seconds).to eq 10
+      end
+
+      it "creates watermark if none is set" do
+        expect{
+          meetup_api.get_next_page
+        }.to change(Watermark, :count).by(1)
+      end
+    end
+
+    context "with error response" do
+      before { meetup_request_error_stub }
+
+      it "returns nil" do
+        meetup_api.get_next_page
+        expect(meetup_api.get_next_page).to be nil
+      end
     end
   end
 


### PR DESCRIPTION
<!--- Which GitHub issue are you closing? -->
closes #38

<!--- What kinds of changes did you make? -->
## Description:
- Added failing spec on `get_next_page` method if non-successful response was returned from the api call
- Added a check that the response had to be successful before attempting to get next page


<!--- How did you test this? -->
<!--- How should someone else test this? -->
## QA:
- [ ] Somewhat hard to QA.  You can verify that:

```
pry> api = Meetup::Api.new(data_type:['Women-Who-Code-Silicon-Valleyxxx', "events"])
pry> api.get_response
pry> api.get_next_page
```
returns nil, though it does anyway without this change.

- [x] You can also locally clear the events and watermarks table and run:

```
$ bundle exec rake data_import:events['Women-Who-Code-Silicon-Valley']
```
with some temporary logging output in the `pagination_link` method to make sure it is still getting hit correctly.



<!--- Any notes you'd like to include... -->
<!--- i.e. database migrations or deployment information. -->
## Notes:



@WomenWhoCode/meet-maynard-reviewers
