### PR TITLE
update log levels for production

### DIFF
--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -105,7 +105,7 @@ module Meetup
 
     def do_request
       @url ||= build_url
-      MMLog.log.debug(sanitized_url)
+      MMLog.log.info(sanitized_url)
 
       @watermark = Watermark.where(url: sanitized_url).first_or_initialize
       etag_str = %Q|#{@watermark.etag}|

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -1,7 +1,7 @@
 namespace :data_import do
   desc "pull pro group data. Usage: rake data_import:pro_group['groupname']"
   task :pro_group, [:group] do |t, args|
-    MMLog.log.debug("START data_import:pro_group")
+    MMLog.log.info("START data_import:pro_group")
     begin
       group = args[:group].presence || 'womenwhocode'
       m = Meetup::Api.new(data_type: ["pro", group, "groups"])
@@ -14,12 +14,12 @@ namespace :data_import do
     rescue Exception => e
       Bugsnag.notify(e)
     end
-    MMLog.log.debug("END data_import:pro_group")
+    MMLog.log.info("END data_import:pro_group")
   end
 
   desc "pull event data. Usage: rake data_import:events['Women-Who-Code-Silicon-Valley']"
   task :events, [:urlname] do |t, args|
-    MMLog.log.debug("START data_import:events")
+    MMLog.log.info("START data_import:events")
     scope = args[:urlname].present? ? GroupStat.where(urlname: args[:urlname]) : GroupStat.all
 
     meetup_api = Meetup::Api.new(data_type: [])
@@ -32,12 +32,12 @@ namespace :data_import do
       )
       Event.retrieve_events(group_stat, meetup_api)
     end
-    MMLog.log.debug("END data_import:events")
+    MMLog.log.info("END data_import:events")
   end
 
   desc "pull rsvp data. Usage: rake data_import:rsvps['Women-Who-Code-Silicon-Valley']"
   task :rsvps, [:urlname] do |t, args|
-    MMLog.log.debug("START data_import:rsvps")
+    MMLog.log.info("START data_import:rsvps")
     if args[:urlname].present?
       scope = Event.without_rsvp.where(group_urlname: args[:urlname])
     else
@@ -55,6 +55,6 @@ namespace :data_import do
       watermark = Watermark.where(url: meetup_api.sanitized_url).first
       RSVPQuestion.retrieve_answers(event, meetup_api) unless watermark
     end
-    MMLog.log.debug("END data_import:rsvps")
+    MMLog.log.info("END data_import:rsvps")
   end
 end


### PR DESCRIPTION
<!--- Which GitHub issue are you closing? -->
closes #59 

<!--- What kinds of changes did you make? -->
## Description:
- We were logging a few things as DEBUG and I changed them to INFO so I can use that in production. 
- LOG_LEVEL=INFO is pretty quiet (no SQL statements) so if there is something else you want logged just LMK and I can add it. 

<!--- How did you test this? -->
<!--- How should someone else test this? -->
## QA:
While view the review app logs with heroku (`heroku logs -t -a REVIEW_APP_NAME`)
- [x]  run `heroku run bundle exec rake data_import:pro_group -a REVIEW_APP_NAME`. SQL and normal output is going to fly by
- [x] Change the review app config var for LOG_LEVEL to INFO, rerun the above statement, you see way fewer lines of output (particularly, no SQL statements).


<!--- Any notes you'd like to include... -->
<!--- i.e. database migrations or deployment information. -->
## Notes:

- [ ] Update LOG_LEVEL to INFO in production config

@WomenWhoCode/meet-maynard-reviewers
