### PR TITLE
Staging to Master 9/19/17

### DIFF
--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -113,12 +113,14 @@ module Meetup
     end
 
     def pagination_link(until_date)
-      target = @response.links.by_rel('next').try(:target)
-      return target.to_s if target && !until_date
+      if response_success?
+        target = @response.links.by_rel('next').try(:target)
+        return target.to_s if target && !until_date
 
-      if target && target.to_s =~ /scroll=since%3A(\d{4}-\d{2}-\d{2})/
-        since_date = Date.strptime($1, "%Y-%m-%d")
-        since_date < until_date ? target.to_s : nil
+        if target && target.to_s =~ /scroll=since%3A(\d{4}-\d{2}-\d{2})/
+          since_date = Date.strptime($1, "%Y-%m-%d")
+          since_date < until_date ? target.to_s : nil
+        end
       end
     end
   end

--- a/lib/meetup/api.rb
+++ b/lib/meetup/api.rb
@@ -105,7 +105,7 @@ module Meetup
 
     def do_request
       @url ||= build_url
-      MMLog.log.debug(sanitized_url)
+      MMLog.log.info(sanitized_url)
 
       @watermark = Watermark.where(url: sanitized_url).first_or_initialize
       etag_str = %Q|#{@watermark.etag}|

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -1,7 +1,7 @@
 namespace :data_import do
   desc "pull pro group data. Usage: rake data_import:pro_group['groupname']"
   task :pro_group, [:group] do |t, args|
-    MMLog.log.debug("START data_import:pro_group")
+    MMLog.log.info("START data_import:pro_group")
     begin
       group = args[:group].presence || 'womenwhocode'
       m = Meetup::Api.new(data_type: ["pro", group, "groups"])
@@ -14,12 +14,12 @@ namespace :data_import do
     rescue Exception => e
       Bugsnag.notify(e)
     end
-    MMLog.log.debug("END data_import:pro_group")
+    MMLog.log.info("END data_import:pro_group")
   end
 
   desc "pull event data. Usage: rake data_import:events['Women-Who-Code-Silicon-Valley']"
   task :events, [:urlname] do |t, args|
-    MMLog.log.debug("START data_import:events")
+    MMLog.log.info("START data_import:events")
     scope = args[:urlname].present? ? GroupStat.where(urlname: args[:urlname]) : GroupStat.all
 
     meetup_api = Meetup::Api.new(data_type: [])
@@ -32,12 +32,12 @@ namespace :data_import do
       )
       Event.retrieve_events(group_stat, meetup_api)
     end
-    MMLog.log.debug("END data_import:events")
+    MMLog.log.info("END data_import:events")
   end
 
   desc "pull rsvp data. Usage: rake data_import:rsvps['Women-Who-Code-Silicon-Valley']"
   task :rsvps, [:urlname] do |t, args|
-    MMLog.log.debug("START data_import:rsvps")
+    MMLog.log.info("START data_import:rsvps")
     if args[:urlname].present?
       scope = Event.without_rsvp.where(group_urlname: args[:urlname])
     else
@@ -55,6 +55,6 @@ namespace :data_import do
       watermark = Watermark.where(url: meetup_api.sanitized_url).first
       RSVPQuestion.retrieve_answers(event, meetup_api) unless watermark
     end
-    MMLog.log.debug("END data_import:rsvps")
+    MMLog.log.info("END data_import:rsvps")
   end
 end

--- a/spec/lib/meetup/api_spec.rb
+++ b/spec/lib/meetup/api_spec.rb
@@ -137,34 +137,45 @@ describe Meetup::Api do
     end
     let(:meetup_api) { Meetup::Api.new(data_type: [], options: {}) }
 
-    before do
-      meetup_request_link_stub
-      meetup_api.get_response
-    end
+    context "with valid response" do
+      before do
+        meetup_request_link_stub
+        meetup_api.get_response
+      end
 
-    it "returns next page data" do
-      expect(meetup_api.get_next_page).to eq response
-    end
+      it "returns next page data" do
+        expect(meetup_api.get_next_page).to eq response
+      end
 
-    it "returns nil if date passed is earlier than since date in link" do
-      expect(meetup_api.get_next_page(Date.new(2017,5,1))).to be nil
-    end
+      it "returns nil if date passed is earlier than since date in link" do
+        expect(meetup_api.get_next_page(Date.new(2017,5,1))).to be nil
+      end
 
-    it "returns nil if no remaining link header" do
-      meetup_api.get_next_page
-      expect(meetup_api.get_next_page).to be nil
-    end
-
-    it "sets remaining_requests and reset_seconds values" do
-      meetup_api.get_next_page
-      expect(meetup_api.remaining_requests).to eq 29
-      expect(meetup_api.reset_seconds).to eq 10
-    end
-
-    it "creates watermark if none is set" do
-      expect{
+      it "returns nil if no remaining link header" do
         meetup_api.get_next_page
-      }.to change(Watermark, :count).by(1)
+        expect(meetup_api.get_next_page).to be nil
+      end
+
+      it "sets remaining_requests and reset_seconds values" do
+        meetup_api.get_next_page
+        expect(meetup_api.remaining_requests).to eq 29
+        expect(meetup_api.reset_seconds).to eq 10
+      end
+
+      it "creates watermark if none is set" do
+        expect{
+          meetup_api.get_next_page
+        }.to change(Watermark, :count).by(1)
+      end
+    end
+
+    context "with error response" do
+      before { meetup_request_error_stub }
+
+      it "returns nil" do
+        meetup_api.get_next_page
+        expect(meetup_api.get_next_page).to be nil
+      end
     end
   end
 


### PR DESCRIPTION
<!--- Which GitHub issue are you closing? -->
PR #61 Set the debug severity to env vars

<!--- How did you test this? -->
<!--- How should someone else test this? -->
## QA:
While view the review app logs with heroku (`heroku logs -t -a REVIEW_APP_NAME`)
- [x]  run `heroku run bundle exec rake data_import:pro_group -a REVIEW_APP_NAME`. SQL and normal output is going to fly by
- [x] Change the review app config var for LOG_LEVEL to INFO, rerun the above statement, you see way fewer lines of output (particularly, no SQL statements).


<!--- Any notes you'd like to include... -->
<!--- i.e. database migrations or deployment information. -->
## Notes:

- [ ] Update LOG_LEVEL to INFO in production config

@WomenWhoCode/meet-maynard-reviewers
